### PR TITLE
Bump Wordpress 'Tested up to' tag to 4.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: inn_nerds, willhaynes24
 Donate link: https://inn.org/donate
 Tags: ads, doubleclick, publishers, news
 Requires at least: 4.0.0
-Tested up to: 4.6
+Tested up to: 4.8
 Stable tag: 0.2.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Merge this once we're sure it works on 4.8.