### PR TITLE
remove spaces in size strings on save

### DIFF
--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -201,8 +201,8 @@ class DCWP_Widget extends WP_Widget {
 		$instance['identifier'] = ( ! empty( $new_instance['identifier'] ) ) ? strip_tags( $new_instance['identifier'] ) : '';
 		$instance['lazyLoad'] = ( ! empty( $new_instance['lazyLoad'] ) ) ? $new_instance['lazyLoad'] : 0 ;
 		$instance['breakpoints'] = $new_instance['breakpoints'];
-		$instance['sizes'] = $new_instance['sizes'];
-		$instance['size'] = $new_instance['size'];
+		$instance['sizes'] = str_replace( ' ', '', $new_instance['sizes'] );
+		$instance['size'] = str_replace( ' ', '', $new_instance['size'] );
 
 		// Flush cache.
 		$this->flush_widget_cache();

--- a/includes/dfw-init.php
+++ b/includes/dfw-init.php
@@ -419,7 +419,12 @@ class DoubleClickAdSlot {
 			$browser_height = 1;
 			$browser_width = (int) $breakpoint->min_width;
 
-			$size_strings = explode( ',', $size );	// eg. 300x250,336x300
+			// Remove any extra spaces in the list of sizes.
+			// (needs to be just a comma-separated list of values)
+			$size = str_replace( ' ', '', $size );
+
+			// eg. 300x250,336x300
+			$size_strings = explode( ',', $size );
 			$size_array = array();
 
 			foreach ( $size_strings as $size ) {


### PR DESCRIPTION
this field expects a comma separated list of ad sizes with no spaces, let's just strip the spaces on save and add a check for backwards compatibility when the value is actually parsed. fixes #32 