### PR TITLE
Refile #61 as a Pull Request, add GitHub files, start 0.3

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Changes
+
+<!-- what changed? -->
+
+- 
+
+## Why
+
+<!-- why did it change? -->
+
+For #
+
+## Testing/Questions
+
+Questions that need to be answered before merging:
+
+- [ ] 
+
+Steps to test this PR:
+
+1. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+We welcome contributions and suggestions to help us improve this project. Please start by [reading our contribution guidelines](https://github.com/INN/docs/blob/master/how-to-work-with-us/contributing.md).
+
+### Workflow:
+
+1.  [Fork this repo](https://help.github.com/articles/fork-a-repo)
+2.  Create a branch (git checkout -b my-branch)
+3.  Stage and commit your changes (git commit -am 'description of my changes')
+4.  Push the changes to your fork (git push origin my-branch)
+5.  [Submit a pull request to the parent repo](https://help.github.com/articles/creating-a-pull-request). Please read our [guide to submitting pull requests](https://github.com/inn/docs/blob/master/how-to-work-with-us/pull-requests.md) to see what we expect in a good pull request message.
+
+We have [a helpful how-to](https://github.com/INN/docs/blob/master/how-to-work-with-us/via-github.md) that walks through this process in more detail if you're new to using Git.
+
+Additionally, you can [create issues](https://github.com/INN/doubleclick-for-wp/issues) on this repo to suggest changes or improvements.
+
+And of course you can always email us: [support@inn.org](mailto:support@inn.org).
+
+### Standards
+
+- Follow all standards from the INN Labs [coding style guide](https://github.com/INN/docs/tree/master/style-guides/code).
+- Use [markdown syntax](http://daringfireball.net/projects/markdown/syntax) for all text documents.
+- Pull requests for new functionality should be accompanied by tests wherever possible.

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -230,7 +230,7 @@ class DoubleClick {
 		/*
 		 * Templates
 		 */
-		if ( is_singular() && ( ! is_post_type_archive() && ! is_home() && ! is_front_page() ) ) {
+		if ( is_singular() && ( ! is_post_type_archive() && ! is_front_page() ) ) {
 			$targeting['Page'][] = 'single';
 		}
 
@@ -250,7 +250,7 @@ class DoubleClick {
 			$targeting['Page'][] = 'search';
 		}
 
-		if ( ! is_home() && ! is_front_page() ) {
+		if ( is_singular() && ( ! is_post_type_archive() && ! is_front_page() ) ) {
 			$cats = get_the_category();
 			$targeting['Category'] = array();
 

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -261,6 +261,14 @@ class DoubleClick {
 			}
 		}
 
+		if ( is_category() ) {
+			$queried_object = get_queried_object();
+			if ( ! isset( $targeting['Category'] ) ) {
+				$targeting['Category'] = array();
+			}
+			$targeting['Category'][] = $c->slug;
+		}
+
 		if ( is_single() ) {
 			$tags = get_the_tags();
 			if ( $tags ) {

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -266,7 +266,7 @@ class DoubleClick {
 			if ( ! isset( $targeting['Category'] ) ) {
 				$targeting['Category'] = array();
 			}
-			$targeting['Category'][] = $c->slug;
+			$targeting['Category'][] = $queried_object->slug;
 		}
 
 		if ( is_single() ) {

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -227,8 +227,10 @@ class DoubleClick {
 			$targeting['Page'][] = 'admin-bar-showing';
 		}
 
-		// Templates
-		if ( is_single() ) {
+		/*
+		 * Templates
+		 */
+		if ( is_singular() && ( ! is_post_type_archive() && ! is_home() && ! is_front_page() ) ) {
 			$targeting['Page'][] = 'single';
 		}
 
@@ -248,11 +250,11 @@ class DoubleClick {
 			$targeting['Page'][] = 'search';
 		}
 
-		if ( is_single() ) {
+		if ( ! is_home() && ! is_front_page() ) {
 			$cats = get_the_category();
 			$targeting['Category'] = array();
 
-			if ( $cats ) {
+			if ( ! empty( $cats ) ) {
 				foreach ( $cats as $c ) {
 					$targeting['Category'][] = $c->slug;
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -33,8 +33,8 @@ For more advanced documentation for developers and advanced users see [the offic
 
 = 0.3 =
 
-- Removes 'single' page targeting from post-type archives and from static front pages. [PR #71](https://github.com/INN/doubleclick-for-wp/pull/71) for [#61](https://github.com/INN/doubleclick-for-wp/issues/61], thanks to GitHub user [dbeniaminov](https://github.com/dbeniaminov).
-- Adds Category targeting on category archive. [PR #71](https://github.com/INN/doubleclick-for-wp/pull/71) for [#61](https://github.com/INN/doubleclick-for-wp/issues/61].
+- Removes 'single' page targeting from post-type archives and from static front pages. [PR #71](https://github.com/INN/doubleclick-for-wp/pull/71) for [#61](https://github.com/INN/doubleclick-for-wp/issues/61), thanks to GitHub user [dbeniaminov](https://github.com/dbeniaminov).
+- Adds Category targeting on category archive. [PR #71](https://github.com/INN/doubleclick-for-wp/pull/71) for [#61](https://github.com/INN/doubleclick-for-wp/issues/61).
 - Adds GitHub Pull Request template and Contributing guidelines files.
 
 = 0.2.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,12 @@ For more advanced documentation for developers and advanced users see [the offic
 
 == Changelog ==
 
+= 0.3 =
+
+- Removes 'single' page targeting from post-type archives and from static front pages. [PR #71](https://github.com/INN/doubleclick-for-wp/pull/71) for [#61](https://github.com/INN/doubleclick-for-wp/issues/61], thanks to GitHub user [dbeniaminov](https://github.com/dbeniaminov).
+- Adds Category targeting on category archive. [PR #71](https://github.com/INN/doubleclick-for-wp/pull/71) for [#61](https://github.com/INN/doubleclick-for-wp/issues/61].
+- Adds GitHub Pull Request template and Contributing guidelines files.
+
 = 0.2.1 =
 
 - Widget now includes a default stylesheet:


### PR DESCRIPTION
## Changes

- Removes 'single' page targeting from post-type archives and from static front pages. [PR #71](https://github.com/INN/doubleclick-for-wp/pull/71) for [#61](https://github.com/INN/doubleclick-for-wp/issues/61), thanks to GitHub user [dbeniaminov](https://github.com/dbeniaminov).
- Adds Category targeting on category archive. [PR #71](https://github.com/INN/doubleclick-for-wp/pull/71) for [#61](https://github.com/INN/doubleclick-for-wp/issues/61).
- Adds GitHub Pull Request template and Contributing guidelines files.
- Starts the changelog for 0.3: https://github.com/INN/doubleclick-for-wp/milestone/1

## Why

This contains @dbeniaminov's fixes from https://github.com/INN/doubleclick-for-wp/issues/61.

Resolves https://github.com/INN/doubleclick-for-wp/issues/61. 

Adds the GitHub files because we didn't have them yet.