### PR TITLE
Relabel the "Identifier" setting in the widget settings

### DIFF
--- a/dfw-widget.php
+++ b/dfw-widget.php
@@ -82,7 +82,7 @@ class DoubleClick_Widget extends WP_Widget {
 		$identifier = ! empty( $instance['identifier'] ) ? $instance['identifier'] : '';
 		?>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'identifier' ) ); ?>"><?php esc_html_e( 'Identifier:' ); ?></label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'identifier' ) ); ?>"><?php esc_html_e( 'Identifier/Ad code:' ); ?></label>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'identifier' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'identifier' ) ); ?>" type="text" value="<?php echo esc_attr( $identifier ); ?>">
 		</p>
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ For more advanced documentation for developers and advanced users see [the offic
 - Updates to `jquery.dfp.js` version 2.4.2, adding `setCentering` support. [PR #67](https://github.com/INN/doubleclick-for-wp/pull/67) for [issue #66](https://github.com/INN/doubleclick-for-wp/issues/66)
 - Removes 'single' page targeting from post-type archives and from static front pages. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61), thanks to GitHub user [dbeniaminov](https://github.com/dbeniaminov).
 - Adds Category targeting on category archive. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61).
+- Adds "Ad unit" label to widget settings for the "Identifier" setting, to match Google's language. [PR #73](https://github.com/INN/doubleclick-for-wp/pull/73) for [issue #26](https://github.com/INN/doubleclick-for-wp/issues/26).
 - Adds GitHub Pull Request template and Contributing guidelines files.
 
 = 0.2.1 =


### PR DESCRIPTION
## Changes

Adds the "Ad code" label on the widget setting:

<img width="449" alt="screen shot 2018-10-17 at 12 04 09 pm" src="https://user-images.githubusercontent.com/1754187/47100134-cf095e80-d204-11e8-96e5-61fdb7ed99ee.png">

## Why

For #26, to match Google's language