### PR TITLE
Add 'Tag' targeting on tag archive pages

### DIFF
--- a/dfw-init.php
+++ b/dfw-init.php
@@ -279,6 +279,15 @@ class DoubleClick {
 			}
 		}
 
+		if ( is_tag() ) {
+			$queried_object = get_queried_object();
+			if ( ! isset( $targeting['Tag'] ) ) {
+				$targeting['Tag'] = array();
+			}
+			$targeting['Tag'][] = $queried_object->slug;
+		}
+
+
 		// return the array of targeting criteria.
 		return apply_filters( 'dfw_targeting_criteria', $targeting );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,8 @@ For more advanced documentation for developers and advanced users see [the offic
 
 - Updates to `jquery.dfp.js` version 2.4.2, adding `setCentering` support. [PR #67](https://github.com/INN/doubleclick-for-wp/pull/67) for [issue #66](https://github.com/INN/doubleclick-for-wp/issues/66)
 - Removes 'single' page targeting from post-type archives and from static front pages. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61), thanks to GitHub user [dbeniaminov](https://github.com/dbeniaminov).
-- Adds Category targeting on category archive. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61).
+- Adds "Category" targeting on category archive. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61).
+- Adds "Tag" targeting on tag archive. [PR #74](https://github.com/INN/doubleclick-for-wp/pull/74) for [issue #29](https://github.com/INN/doubleclick-for-wp/issues/29).
 - Adds "Ad unit" label to widget settings for the "Identifier" setting, to match Google's language. [PR #73](https://github.com/INN/doubleclick-for-wp/pull/73) for [issue #26](https://github.com/INN/doubleclick-for-wp/issues/26).
 - Adds GitHub Pull Request template and Contributing guidelines files.
 


### PR DESCRIPTION

## Changes

- Adds 'Tag' targeting on tag archive pages

## Why

Closes https://github.com/INN/doubleclick-for-wp/issues/29, fixing a feature difference between tags and categories, since after #72 we had "Category" targeting for category archives.

## Testing/Questions

1. Create a tag.
2. Go to the tag archive page.
3. Search source code for "targeting" and verify that the JSON contains the tag.