### PR TITLE
Miscellaneous uninitialized variables cleanup

### DIFF
--- a/dfw-init.php
+++ b/dfw-init.php
@@ -119,9 +119,21 @@ class DoubleClick {
 	 *
 	 * @param string       $identifier the breakpoint to register.
 	 * @param string|array $args additional args.
+	 * @return Boolean     Whether or not a breakpoing was registered.
 	 */
 	public function register_breakpoint( $identifier, $args = null ) {
-		$this->breakpoints[ $identifier ] = new DoubleClickBreakpoint( $identifier, $args );
+		if ( is_string( $identifier) ) {
+			$this->breakpoints[ $identifier ] = new DoubleClickBreakpoint( $identifier, $args );
+			return true;
+		} else if ( is_array( $identifier ) ) {
+			$this->breakpoints[ $identifier['identifier'] ] = new DoubleClickBreakpoint( $identifier['identifier'], $args );
+			return true;
+		} else {
+			if ( WP_DEBUG ) {
+				error_log( 'DoubleClick->register_breakpoint() is being called with the wrong arguments somewhere.' );
+			}
+			return false;
+		}
 	}
 
 	/**
@@ -502,6 +514,15 @@ class DoubleClickBreakpoint {
 
 		if ( isset( $args['_option'] ) && $args['_option'] ) {
 			$this->option = true;
+		}
+
+
+		// Same, but with different spelling
+		if ( isset( $args['max-width'] ) ) {
+			$this->max_width = $args['max-width'];
+		}
+		if ( isset( $args['min-width'] ) ) {
+			$this->min_width = $args['min-width'];
 		}
 
 		$this->identifier = $identifier;

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -119,7 +119,7 @@ class DoubleClick {
 	 *
 	 * @param string       $identifier the breakpoint to register.
 	 * @param string|array $args additional args.
-	 * @return Boolean     Whether or not a breakpoing was registered.
+	 * @return Boolean     Whether or not a breakpoint was registered.
 	 */
 	public function register_breakpoint( $identifier, $args = null ) {
 		if ( is_string( $identifier) ) {

--- a/dfw-options.php
+++ b/dfw-options.php
@@ -129,8 +129,6 @@ function dfw_breakpoints_input() {
 
 	$breakpoints = maybe_unserialize( get_option( 'dfw_breakpoints' ) );
 
-	error_log(var_export( $breakpoints, true));
-
 	/*
 	 * Note here that these are not individually named inputs!
 	 * These are all alike, forming a singular array that dfw_breakpoints_save()
@@ -169,7 +167,6 @@ function dfw_breakpoints_input() {
 }
 
 function dfw_breakpoints_save( $value ) {
-	error_log(var_export( $value , true));
 	$breakpoints = array();
 	$groups = array_chunk( $value, 3 );
 

--- a/dfw-options.php
+++ b/dfw-options.php
@@ -7,11 +7,11 @@
  */
 function dfw_plugin_menu() {
 	add_options_page(
-		'DoubleClick for WordPress', 	// $page_title title of the page.
-		'DoubleClick', 	                // $menu_title the text to be used for the menu.
-		'manage_options', 				// $capability required capability for display.
-		'doubleclick-for-wordpress', 	// $menu_slug unique slug for menu.
-		'dfw_option_page_html' 			// $function callback.
+		'DoubleClick for WordPress', // $page_title title of the page.
+		'DoubleClick', 	             // $menu_title the text to be used for the menu.
+		'manage_options',            // $capability required capability for display.
+		'doubleclick-for-wordpress', // $menu_slug unique slug for menu.
+		'dfw_option_page_html'       // $function callback.
 	);
 }
 add_action( 'admin_menu', 'dfw_plugin_menu' );

--- a/dfw-options.php
+++ b/dfw-options.php
@@ -129,6 +129,15 @@ function dfw_breakpoints_input() {
 
 	$breakpoints = maybe_unserialize( get_option( 'dfw_breakpoints' ) );
 
+	error_log(var_export( $breakpoints, true));
+
+	/*
+	 * Note here that these are not individually named inputs!
+	 * These are all alike, forming a singular array that dfw_breakpoints_save()
+	 * breaks into an associative array using array_chunk()
+	 *
+	 * @todo: instead of $i being 5, count $breakpoints, then output a foreach of $breakpoints plus ( 5-n, minimum 1 ) additional fields.
+	 */
 	$i = 0;
 	while ( $i < 5 ) {
 		$identifier = ( isset( $breakpoints[ $i ]['identifier'] ) )? $breakpoints[ $i ]['identifier'] : '';
@@ -160,6 +169,7 @@ function dfw_breakpoints_input() {
 }
 
 function dfw_breakpoints_save( $value ) {
+	error_log(var_export( $value , true));
 	$breakpoints = array();
 	$groups = array_chunk( $value, 3 );
 

--- a/dfw-widget.php
+++ b/dfw-widget.php
@@ -126,7 +126,7 @@ class DoubleClick_Widget extends WP_Widget {
 				type="checkbox"
 				name="<?php echo esc_attr( $this->get_field_name( 'lazyLoad' ) ); ?>"
 				value="1"
-				<?php if ( $instance['lazyLoad'] ) { echo 'checked';} ?>
+				<?php if ( isset( $instance['lazyLoad'] ) && $instance['lazyLoad'] ) { echo 'checked';} ?>
 				><label>Only load ad once it comes into view on screen.</label><br/>
 		</p>
 		<hr/><br>

--- a/dfw.php
+++ b/dfw.php
@@ -4,8 +4,11 @@ Plugin Name: DoubleClick for WordPress
 Description: A simple way to serve DoubleClick ads in WordPress.
 Version:     0.2
 Author:      innlabs, Will Haynes for INN
-Author URI:  https://github.com/INN/DoubleClick-for-WordPress/blob/master/dfw.php
- */
+Author URI:  https://labs.inn.org/
+License:     GPL Version 2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: dfw
+*/
 
 define( 'DFP_VERSION', '0.2.0' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -37,8 +37,11 @@ For more advanced documentation for developers and advanced users see [the offic
 - Removes 'single' page targeting from post-type archives and from static front pages. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61), thanks to GitHub user [dbeniaminov](https://github.com/dbeniaminov).
 - Adds "Category" targeting on category archive. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61).
 - Adds "Tag" targeting on tag archive. [PR #74](https://github.com/INN/doubleclick-for-wp/pull/74) for [issue #29](https://github.com/INN/doubleclick-for-wp/issues/29).
+- Fixes a number of PHP warnings and errors, including [issue #8](https://github.com/INN/doubleclick-for-wp/issues/8) and [issue #37](https://github.com/INN/doubleclick-for-wp/issues/37). ([PR #76](https://github.com/INN/doubleclick-for-wp/pull/76))
 - Adds "Ad unit" label to widget settings for the "Identifier" setting, to match Google's language. [PR #73](https://github.com/INN/doubleclick-for-wp/pull/73) for [issue #26](https://github.com/INN/doubleclick-for-wp/issues/26).
 - Adds GitHub Pull Request template and Contributing guidelines files.
+- Adds a plugin text domain: `dfw`. ([PR #76](https://github.com/INN/doubleclick-for-wp/pull/76))
+- Adds the GPL2 license to the plugin header; this plugin has been GPL2 since 2015 but that wasn't marked in a WordPress-accessible way. ([PR #76](https://github.com/INN/doubleclick-for-wp/pull/76))
 
 = 0.2.1 =
 


### PR DESCRIPTION
## Changes

- Fixes Undefined Index: lazyLoad in widget
- Fixes visibility problem for widget constructor
- Fixes a weird error on first save of settings: 
- Fixes https://github.com/INN/doubleclick-for-wp/issues/37
- Maybe fixes https://github.com/INN/doubleclick-for-wp/issues/8, specifically the part that puts a PHP Notice in the value of one of the inputs.
- Slaps a big todo in dfw-options.php for improving the array. Will spin that out into a new issue for later work.
- Sets the text-domain to 'dfw'; we've had the text domain in use earlier but it wasn't defined anywhere.
- Some code-style cleanup
- Adds license, license URI to plugin header
- Updates author URI to labs.inn.org

## Testing/Questions

Questions that need to be answered before merging:

- [x] Do settings saved in previous versions of this plugin still work in this version of the plugin?

Steps to test this PR:

1. Save settings using an old version of this plugin, 0.2.1.
2. Check out this branch
3. Do the settings on the settings page match what they previously were?
