### PR TITLE
DFP to GAM, DFW to SCAMP

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ For #
 
 Questions that need to be answered before merging:
 
+- [ ] Does it update the changelog in `readme.txt` with appropriate information?
 - [ ] 
 
 Steps to test this PR:

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "nerds@inn.org"
   ],
-  "description": "WordPress plugin for serving DFP ads.",
+  "description": "WordPress plugin for serving Google Ad Manager ads.",
   "main": "dfw.php",
   "moduleType": [
     "es6"
@@ -13,6 +13,8 @@
   "keywords": [
     "WordPress",
     "DFP",
+    "DoubleClick",
+    "Google Ad Manager",
     "Google",
     "Advertising"
   ],

--- a/dfw-init.php
+++ b/dfw-init.php
@@ -31,7 +31,7 @@ add_action( 'wp_loaded', 'dfw_add_action' );
 class DoubleClick {
 
 	/**
-	 * Network code from DFP.
+	 * Network code from GAM.
 	 *
 	 * @var int
 	 */
@@ -305,9 +305,9 @@ class DoubleClick {
 	}
 
 	/**
-	 * Place a DFP ad.
+	 * Place a Google Ad Manager ad.
 	 *
-	 * @param string       $identifier A DFP identifier.
+	 * @param string       $identifier A Google Ad Manager ad unit identifier.
 	 * @param string|array $sizes the dimensions the ad could be.
 	 * @param string|array $args additional args.
 	 */
@@ -328,7 +328,7 @@ class DoubleClick {
 	/**
 	 * Build the ad code.
 	 *
-	 * @param string       $identifier A DFP identifier.
+	 * @param string       $identifier A Google Ad Manager ad identifier.
 	 * @param string|array $sizes the dimensions the ad could be.
 	 * @param string|array $args additional args.
 	 */
@@ -374,10 +374,13 @@ class DoubleClick {
 }
 
 
+/**
+ * Store information for a given ad on a page
+ */
 class DoubleClickAdSlot {
 
 	/**
-	 * DFP ad code.
+	 * Google Ad Manager ad code/identifier.
 	 *
 	 * @var String.
 	 */

--- a/dfw-options.php
+++ b/dfw-options.php
@@ -7,8 +7,8 @@
  */
 function dfw_plugin_menu() {
 	add_options_page(
-		'DoubleClick for WordPress', // $page_title title of the page.
-		'DoubleClick', 	             // $menu_title the text to be used for the menu.
+		'Super Cool Ad Manager Plugin', // $page_title title of the page.
+		'DoubleClick/Ad Manager',       // $menu_title the text to be used for the menu.
 		'manage_options',            // $capability required capability for display.
 		'doubleclick-for-wordpress', // $menu_slug unique slug for menu.
 		'dfw_option_page_html'       // $function callback.
@@ -28,7 +28,7 @@ function dfw_option_page_html() {
 	}
 
 	echo '<div class="wrap">';
-	echo '<h2>DoubleClick for WordPress Options</h2>';
+	echo '<h2>Super Cool Ad ManagerOptions</h2>';
 	echo '<form method="post" action="options.php">';
 
 	settings_fields( 'doubleclick-for-wordpress' );
@@ -72,7 +72,7 @@ function dfw_register_options() {
 	// Network Code
 	add_settings_field(
 		'dfw_network_code',
-		'DoubleClick Network Code',
+		'Google Ad Manager Network Code',
 		'dfw_network_code_input',
 		'doubleclick-for-wordpress',
 		'dfw_network_options'
@@ -94,7 +94,7 @@ function dfw_register_options() {
 add_action( 'admin_init', 'dfw_register_options' );
 
 function dfw_settings_section_intro() {
-	echo "Enter a DoubleClick for Publisher's Network Code ( <a href='https://developers.google.com/doubleclick-publishers/docs/start#signup' target='_blank'>?</a> )";
+	echo "Enter a Google Ad Manager Network Code ( <a href='https://developers.google.com/doubleclick-publishers/docs/start#signup' target='_blank'>?</a> )";
 }
 
 function dfw_breakpoints_section_intro() {

--- a/dfw-widget.php
+++ b/dfw-widget.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The DoubleClick Ad widget, and related functions
+ * The Google Ad Manager Ad widget, and related functions
  */
 
 /**
@@ -14,8 +14,8 @@ class DoubleClick_Widget extends WP_Widget {
 	public function __construct() {
 		parent::__construct(
 			'doubleclick_widget', // Base ID
-			__( 'DoubleClick Ad', 'dfw' ), // Name
-			array( 'description' => __( 'Serve ads from DFP.', 'dfw' ) ) // Args.
+			__( 'Google Ad Manager Ad', 'dfw' ), // Name
+			array( 'description' => __( 'Serve ads from Google Ad Manager.', 'dfw' ) ) // Args.
 		);
 	}
 
@@ -51,7 +51,7 @@ class DoubleClick_Widget extends WP_Widget {
 		} else {
 			echo sprintf(
 				'<!-- %1$s %2$s-->',
-				esc_html__( 'This DoubleClick for WordPress widget is not appearing because the widget has no sizes set for its breakpoints.', 'dfw' ),
+				esc_html__( 'This Google Ad Manager Ad widget is not appearing because the widget has no sizes set for its breakpoints.', 'dfw' ),
 				var_export( $instance, true )
 			);
 			return;

--- a/docs/Developer-API.md
+++ b/docs/Developer-API.md
@@ -81,7 +81,7 @@ $DoubleClick->place_ad('my-identifier',$sizes,$args);
 
 __$identifer__
 
-`String` The DFP identifier for an ad unit (DFP does not require you to create an identifier. If this does not match a value defined in DFP, a network-wide ad will still be requested).
+`String` The Google Ad Manager identifier for an ad unit (GAM does not require you to create an identifier. If this does not match a value defined in GAM, a network-wide ad will still be requested).
 
 __$sizes__
 

--- a/docs/Targeting.md
+++ b/docs/Targeting.md
@@ -1,6 +1,6 @@
 # Targeting
 
-This plugin implements advanced DFP targeting criteria to allow trafficers to specify pages or groups of pages where line items should serve.
+This plugin implements advanced Google Ad Manager targeting criteria to allow trafficers to specify pages or groups of pages where line items should serve.
 
 * * *
 
@@ -52,15 +52,15 @@ Additional targeting criteria set by the URL of the page.
 
 	> eg. target the url [example.com/?**movie=12**](http://example.com/news/) with the targeting string 'p:12'
 
-__Warning__: Targeting strings are limited to 40 characters long by DFP. Targeting URLIs or domains longer than that will result in error.
+__Warning__: Targeting strings are limited to 40 characters long by Google Ad Manager. Targeting URLIs or domains longer than that will result in error.
 
 This plugin uses `jQuery.dfp.js`, which provides [a number of other targeting parameters](https://github.com/coop182/jquery.dfp.js#default-url-targeting).
 
 * * *
 
-## 3. Defining targeting criteria in DFP
+## 3. Defining targeting criteria in Google Ad Manager
 
-DFP needs to be told what filter keys exist before they can be used.
+Google Ad Manager needs to be told what filter keys exist before they can be used.
 
 #### Example
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,14 +1,14 @@
-# ![Screenshot](img/dfw.png) DoubleClick for WordPress
+# ![Screenshot](img/dfw.png) Super Cool Ad Manager Plugin
 
-Serve DoubleClick ads natively in WordPress. Built to make serving responsive ads easy.
+Serve Google Ad Manager ads natively in WordPress. Built to make serving responsive ads easy.
 
-Built by the [Institute for Nonprofit News](http://inn.org/), DoubleClick for WordPress works with [Project Largo](http://largoproject.org/) or any standalone WordPress blog.
+Built by the [Institute for Nonprofit News](http://inn.org/), Super Cool Ad Manager Plugin works with [Project Largo](http://largoproject.org/) or any standalone WordPress blog.
 
 * * *
 
 ## 1. What is this thing?
 
-This WordPress plugin serves inventory from a DoubleClick for Publisher account on a WordPress site.
+This WordPress plugin serves inventory from a Google Ad Manager account on a WordPress site.
 
 No need to copy and paste ad codes or header tags — the plugin generates all of this on its own.
 
@@ -20,7 +20,7 @@ For the most basic integration, only two steps are necessary.
 
 #### __2.1. Define Settings__ —
 
-Under _Settings > DoubleClick for WordPress_ update the field with your network code from DFP, and a place to define breakpoints to serve ads to.
+Under **Settings > DoubleClick/Ad Manager** update the field with your network code from Google Ad Manager, and a place to define breakpoints to serve ads to.
 
 **NOTE:** Both Network Code and Breakpoints may be defined by a developer within the WordPress theme. If a developer already defined these values within the theme, a user will know based on their display in the plugin Settings page.
 
@@ -34,7 +34,7 @@ Advertisements are placed in two ways.
 
 ![Screenshot](img/widget.png)
 
- * The __identifier__ field is the name of a line item in DoubleClick for Publishers. If an line item with the same identifier in DoubleClick matches the identifier set in the widget, the ad will load (subject to conditional targeting set in DFP admin). If the identifier is blank or doesn't match a line item in DFP, the plugin attempts to load inventory from anywhere in the DFP account.
+ * The __identifier__ field is the name of a line item in Google Ad Manager. If an line item with the same identifier in Google Ad Manager matches the identifier set in the widget, the ad will load (subject to conditional targeting set in Google Ad Manager admin). If the identifier is blank or doesn't match a line item in Google Ad Manager, the plugin attempts to load inventory from anywhere in the Google Ad Manager account.
 
  * Based on breakpoints defined in plugin settings or theme, an __Inventory Size__ can be defined for each breakpoint set either in the plugin settings or via theme function.
    * For an ad the same __Inventory Size__ at every breakpoint, use that size in each breakpoint (i.e. `300x250`).

--- a/inc/block.php
+++ b/inc/block.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Functions related to the DFW plugin's blocks.
+ * Functions related to the SCAMP plugin's blocks.
  *
  * @link https://github.com/INN/doubleclick-for-wp/issues/70
  */

--- a/js/jquery.dfw.js
+++ b/js/jquery.dfw.js
@@ -1,6 +1,8 @@
 /**
- * A few lines of javascript to help the DoubleClick for WordPress plugin.
- * Extends jquery.dfw.min.js with some event listeners specific to us.
+ * A few lines of javascript to help the Google Ad Manager for WordPress plugin
+ * Extends jquery.dfw.min.js with some event listeners specific to us:
+ *
+ * - lazyload
  */
 (function() {
 	var $ = jQuery;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,2 +1,2 @@
-site_name: DoubleClick for WordPress
+site_name: Super Cool Ad Manager Plugin
 theme: readthedocs

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
-# DoubleClick for WordPress 
+# Super Cool Ad Manager Plugin
 
 Serve DoubleClick ads natively in WordPress. Built to make serving responsive ads easy.
 
 [Read the documentation on GitHub](https://github.com/INN/DoubleClick-for-WordPress/tree/master/docs).
+
+This plugin was named "DoubleClick for WordPress" [until](https://github.com/inn/doubleclick-for-wp/issues/69) Google [renamed DoubleClick for Publishers to Google Ad Manager](https://www.blog.google/products/admanager/introducing-google-ad-manager/).

--- a/readme.txt
+++ b/readme.txt
@@ -33,6 +33,7 @@ For more advanced documentation for developers and advanced users see [the offic
 
 = 0.3 =
 
+- Rebrands from "DoubleClick for WordPress" to "Super Cool Ad Manager Plugin", because [Google merged DoubleClick for Publishers into Google Ad Manager](https://www.blog.google/products/admanager/introducing-google-ad-manager/).
 - Updates to `jquery.dfp.js` version 2.4.2, adding `setCentering` support. [PR #67](https://github.com/INN/doubleclick-for-wp/pull/67) for [issue #66](https://github.com/INN/doubleclick-for-wp/issues/66)
 - Removes 'single' page targeting from post-type archives and from static front pages. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61), thanks to GitHub user [dbeniaminov](https://github.com/dbeniaminov).
 - Adds "Category" targeting on category archive. [PR #72](https://github.com/INN/doubleclick-for-wp/pull/72) for [issue #61](https://github.com/INN/doubleclick-for-wp/issues/61).


### PR DESCRIPTION
## Changes

- Rebrands the plugin to Super Cool Ad Manager Plugin
- Replaces references to DFP with GAM

## Why

- Because of https://www.blog.google/products/admanager/introducing-google-ad-manager/

For #69

## Testing/Questions

Questions that need to be answered before merging:

- [ ] where is the screenshot in https://wordpress.org/plugins/doubleclick-for-wp/ coming from and how do we update it?