### PR TITLE
improve backwards-compatibility support after VIP compatibility changes 

### DIFF
--- a/dfw-options.php
+++ b/dfw-options.php
@@ -143,7 +143,25 @@ function dfw_breakpoints_input() {
 	while ( $i < 5 ) {
 		$identifier = ( isset( $breakpoints[ $i ]['identifier'] ) )? $breakpoints[ $i ]['identifier'] : '';
 		$min_width = ( isset( $breakpoints[ $i ]['min-width'] ) )? $breakpoints[ $i ]['min-width'] : '';
-		$max_width = ( isset( $breakpoints[ $i ]['max-width'] ) )? $breakpoints[ $i ]['max-width'] : ''; ?>
+		$max_width = ( isset( $breakpoints[ $i ]['max-width'] ) )? $breakpoints[ $i ]['max-width'] : '';
+
+		// fallbacks for post-https://github.com/INN/doubleclick-for-wp/pull/46 compatibility.
+		if ( empty( $min_width ) && isset( $breakpoints[ $i ][ 'minWidth' ] ) ) {
+			$min_width = ( isset( $breakpoints[ $i ]['minWidth'] ) )? $breakpoints[ $i ]['minWidth'] : '';
+		}
+		if ( empty( $max_width ) && isset( $breakpoints[ $i ][ 'maxWidth' ] ) ) {
+			$max_width = ( isset( $breakpoints[ $i ]['maxWidth'] ) )? $breakpoints[ $i ]['maxWidth'] : '';
+		}
+
+		// fallbacks, continued.
+		if ( empty( $min_width ) && isset( $breakpoints[ $i ][ 'min-width' ] ) ) {
+			$min_width = ( isset( $breakpoints[ $i ]['min-width'] ) )? $breakpoints[ $i ]['min-width'] : '';
+		}
+		if ( empty( $max_width ) && isset( $breakpoints[ $i ][ 'max-width' ] ) ) {
+			$max_width = ( isset( $breakpoints[ $i ]['max-width'] ) )? $breakpoints[ $i ]['max-width'] : '';
+		}
+
+		?>
 		<input value="<?php echo esc_attr( $identifier ); ?>"
 				placeholder="Name"
 				name="dfw_breakpoints[]"

--- a/docs/Developer-API.md
+++ b/docs/Developer-API.md
@@ -44,7 +44,7 @@ __$identifier__
 
 __$args__
 
-`Array` An array of properties about the breakpoint. Currently the only keys supported are minWidth and maxWidth.
+`Array` An array of properties about the breakpoint. Currently the only keys supported are min_width and max_width.
 
 * * *
 

--- a/inc/class-doubleclickbreakpoint.php
+++ b/inc/class-doubleclickbreakpoint.php
@@ -36,25 +36,25 @@ class DoubleClickBreakpoint {
 	public $option;
 
 	public function __construct( $identifier, $args = null ) {
+		// specify all the options because there has been come confusion, historically
 		if ( isset( $args['min_width'] ) ) {
 			$this->min_width = $args['min_width'];
+		} else if ( isset( $args['minWidth'] ) ) {
+			$this->min_width = $args['minWidth'];
+		} else if ( isset( $args['min-width'] ) ) {
+			$this->max_width = $args['min-width'];
 		}
 
 		if ( isset( $args['max_width'] ) ) {
 			$this->max_width = $args['max_width'];
+		} else if ( isset( $args['maxWidth'] ) ) {
+			$this->max_width = $args['maxWidth'];
+		} else if ( isset( $args['max-width'] ) ) {
+			$this->max_width = $args['max-width'];
 		}
 
 		if ( isset( $args['_option'] ) && $args['_option'] ) {
 			$this->option = true;
-		}
-
-
-		// Same, but with different spelling
-		if ( isset( $args['max-width'] ) ) {
-			$this->max_width = $args['max-width'];
-		}
-		if ( isset( $args['min-width'] ) ) {
-			$this->min_width = $args['min-width'];
 		}
 
 		$this->identifier = $identifier;


### PR DESCRIPTION
## Changes

- Adds some conditionals for fallback for previous variable names that were change in https://github.com/INN/doubleclick-for-wp/pull/46
- Corrects some docs that were incorrect as a result of #46.

## Why

- Because https://github.com/INN/doubleclick-for-wp/pull/46 changed some global variables, properties, methods, array keys, and similar things.


For https://github.com/INN/doubleclick-for-wp/pull/46

## Testing/Questions

Questions that need to be answered before merging:

- [x] Does it update the changelog in `readme.txt` with appropriate information? — mostly handled in the branch 83-tag-0.3
- [x] Does a plugin settings, version 0.2.1, display in 0.3? Is it saved correctly?
- [x] Does a widget, version 0.2.1, display in 0.3? Is it saved correctly?

Steps to test this PR:

1. set up the plugin at v0.2 on a fresh install of WordPress, and configure it
2. Upgrade the plugin to this branch.
3. Answer the questions above.
