### PR TITLE
Update class-doubleclick.php

### DIFF
--- a/inc/class-doubleclick.php
+++ b/inc/class-doubleclick.php
@@ -243,6 +243,8 @@ class DoubleClick {
 		 */
 		if ( is_singular() && ( ! is_post_type_archive() && ! is_front_page() ) ) {
 			$targeting['Page'][] = 'single';
+			global $post;
+			$targeting['inURL'][] = $post->post_name;
 		}
 
 		if ( is_post_type_archive() ) {


### PR DESCRIPTION
add 'inurl' page targeting to single posts and pages

## Changes

- <!-- added post-slug to 'inurl' parameter, to target individual pages for ads -->

## Why

- <!-- 'inurl' targeting was listed in documentation earlier, but did not work. This solution adds the parameter in, but only for pages/posts (lines 246-247) -->

For #

## Testing/Questions

Questions that need to be answered before merging:

- [ ] Does it update the changelog in `readme.txt` with appropriate information?
- [ ] 

Steps to test this PR:

1. 
